### PR TITLE
Add release drafter file

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What's Changed
+
+  $CHANGES


### PR DESCRIPTION
The Release Drafter updates releases, so it requires write access to this repository. When you install the app, you don't need to add it to your entire GitHub account. Only install it on this repository. Release Drafter doesn't work just out of the box. If you use this in the future, you'll need to add .github/release-drafter.yml to your repository. We'll take care of adding this in a separate PR.